### PR TITLE
Unify RUN commands and add pip install for altair-ally and deepchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM quay.io/jupyter/minimal-notebook:afe30f0c9ad8
 
 COPY conda-linux-64.lock /tmp/conda-linux-64.lock
 
-RUN mamba update --quiet --file /tmp/conda-linux-64.lock
-RUN mamba clean --all -y -f
-RUN fix-permissions "${CONDA_DIR}"
-RUN fix-permissions "/home/${NB_USER}"
+RUN mamba update --quiet --file /tmp/conda-linux-64.lock \
+    && mamba clean --all -y -f \
+    && fix-permissions "${CONDA_DIR}" \
+    && fix-permissions "/home/${NB_USER}"
 
+RUN pip install \
+    deepchecks==0.19.1 \
+    altair-ally==0.1.1


### PR DESCRIPTION
Unified the RUN command to reduce build layers.
Include the RUN command for pip install altair-ally and deepchecks.